### PR TITLE
added classifier_training

### DIFF
--- a/src/flows/classifier_training.py
+++ b/src/flows/classifier_training.py
@@ -6,7 +6,7 @@ from prefect import flow
 
 from image_classifier_dojo.schemas import TrainingRunConfig
 
-from tasks.run_containerized_classifier_training import run_container
+from src.tasks.run_containerized_classifier_training import run_container
 
 
 @flow(log_prints=True)

--- a/src/flows/classifier_training.py
+++ b/src/flows/classifier_training.py
@@ -1,0 +1,20 @@
+import os
+from pathlib import Path
+import shutil
+
+from prefect import flow
+
+from image_classifier_dojo.schemas import TrainingRunConfig
+
+from tasks.run_containerized_classifier_training import run_container
+
+
+@flow(log_prints=True)
+def run_dojo_train_multiclass(datasets_dir:str, experiments_dir:str, training_run_config: TrainingRunConfig):
+    """Flow: Run Image Classifier Dojo using the given parameters."""
+
+    run_container(datasets_dir, experiments_dir, ['TRAIN','MULTICLASS'], training_run_config)
+
+# Deploy the flow
+if __name__ == "__main__":
+    run_dojo_train_multiclass.serve(name="image-classifier-dojo_train-multiclass")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -45,6 +45,7 @@ httpx==0.28.1
 humanize==4.12.2
 hyperframe==6.1.0
 idna==3.10
+image_classifier_dojo @ git+https://github.com/WHOIGit/image-classifier-dojo.git@v0.2.0
 importlib_metadata==8.6.1
 Jinja2==3.1.6
 jinja2-humanize-extension==0.4.0
@@ -74,7 +75,7 @@ provenance-client @ git+https://github.com/WHOIGit/amplify-provenance-client.git
 pycparser==2.22
 pydantic==2.11.1
 pydantic-extra-types==2.10.3
-pydantic-settings==2.8.1
+pydantic-settings~=2.11.0
 pydantic_core==2.33.0
 Pygments==2.19.1
 python-dateutil==2.9.0.post0

--- a/src/tasks/run_containerized_classifier_training.py
+++ b/src/tasks/run_containerized_classifier_training.py
@@ -1,0 +1,35 @@
+from prefect import task
+import docker
+
+from prov import on_task_complete
+from image_classifier_dojo.schemas import TrainingRunConfig
+
+@task(on_completion=[on_task_complete])
+def run_container(data_dir: str, output_dir: str, subcommands:list, training_run_config: TrainingRunConfig):
+    """
+    Run Image Classifier Dojo in a Docker container.
+    """
+
+    client = docker.from_env()
+    
+    volumes = {
+        data_dir: {'bind': '/workspace/datasets', 'mode': 'rw'},
+        output_dir: {'bind': '/app/experiments', 'mode': 'rw'}
+    }
+    
+    command = f"{' '.join(subcommands)}' " \
+              f"--logger {training_run_config.logger.model_dump_json()} " \
+              f"--dataset_config {training_run_config.dataset_config.model_dump_json()} " \
+              f"--model {training_run_config.model.model_dump_json()} " \
+              f"--training {training_run_config.training.model_dump_json()} " \
+              f"--runtime {training_run_config.runtime.model_dump_json()} "
+    container = client.containers.run(
+        'harbor-registry.whoi.edu/amplify/image_classifier_dojo:v0.2.0',
+        command,
+        volumes=volumes,
+        device_requests=[docker.types.DeviceRequest(device_ids=["all"], capabilities=[["gpu"]])],
+        ipc_mode="host",
+        remove=True,
+        detach=False,
+        shm_size='8g',
+    )

--- a/src/tasks/run_containerized_classifier_training.py
+++ b/src/tasks/run_containerized_classifier_training.py
@@ -1,4 +1,4 @@
-from prefect import task
+from prefect import task, get_run_logger
 import docker
 
 from prov import on_task_complete
@@ -11,25 +11,64 @@ def run_container(data_dir: str, output_dir: str, subcommands:list, training_run
     """
 
     client = docker.from_env()
-    
+    logger = get_run_logger()
+
     volumes = {
         data_dir: {'bind': '/workspace/datasets', 'mode': 'rw'},
         output_dir: {'bind': '/app/experiments', 'mode': 'rw'}
     }
-    
+
     command = f"{' '.join(subcommands)}' " \
               f"--logger {training_run_config.logger.model_dump_json()} " \
               f"--dataset_config {training_run_config.dataset_config.model_dump_json()} " \
               f"--model {training_run_config.model.model_dump_json()} " \
               f"--training {training_run_config.training.model_dump_json()} " \
               f"--runtime {training_run_config.runtime.model_dump_json()} "
-    container = client.containers.run(
-        'harbor-registry.whoi.edu/amplify/image_classifier_dojo:v0.2.0',
-        command,
-        volumes=volumes,
-        device_requests=[docker.types.DeviceRequest(device_ids=["all"], capabilities=[["gpu"]])],
-        ipc_mode="host",
-        remove=True,
-        detach=False,
-        shm_size='8g',
-    )
+    try:
+        container = client.containers.run(
+            'harbor-registry.whoi.edu/amplify/image_classifier_dojo:v0.2.0',
+            command,
+            shm_size='8g',
+            volumes=volumes,
+            device_requests=[docker.types.DeviceRequest(device_ids=["all"], capabilities=[["gpu"]])],
+            ipc_mode="host",
+            remove=False,  # Don't auto-remove so we can get logs on failure
+            detach=True,
+        )
+
+    # Stream logs in real-time
+        try:
+            for line in container.logs(stream=True, follow=True):
+                logger.info(line.decode('utf-8').rstrip())
+        except Exception as log_error:
+            logger.error(f"Error streaming logs: {log_error}")
+
+        # Wait for container to finish and check exit code
+        result = container.wait()
+        exit_code = result['StatusCode']
+
+        if exit_code != 0:
+            # Get the full logs for error reporting
+            full_logs = container.logs(stdout=True, stderr=True).decode('utf-8')
+            container.remove()
+            logger.error(f"Container failed with exit code {exit_code}")
+            logger.error(f"Full container output:\n{full_logs}")
+            raise RuntimeError(f"Docker container failed with exit code {exit_code}")
+
+        # Clean up container on success
+        container.remove()
+        logger.info("✓ Validation completed successfully")
+
+    except docker.errors.ContainerError as e:
+        logger.error(f"Container failed with exit code {e.exit_status}")
+        logger.error(f"Command: {e.command}")
+        if e.stderr:
+            stderr = e.stderr.decode('utf-8') if isinstance(e.stderr, bytes) else str(e.stderr)
+            logger.error(f"Container stderr:\n{stderr}")
+        raise RuntimeError(f"Docker container failed with exit code {e.exit_status}")
+    except docker.errors.APIError as e:
+        logger.error(f"Docker API error: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error running container: {str(e)}")
+        raise


### PR DESCRIPTION
a new task and flow! 

docker image used by task is at `harbor-registry.whoi.edu/amplify/image_classifier_dojo:v0.2.0` 

I added `image_classifier_dojo @ git+https://github.com/WHOIGit/image-classifier-dojo.git@v0.2.0` to requirements. This does not contain large libs like torch, mostly just small dependencies like pydantic. The heavier stuff for actual training (like torch package) gets pip imported using "image_classifier_dojo __[train]__ ". This way, you can import just the schemas directly from the project. 

I also updated a few requirements to a newer version for compatibility with `image_classifier_dojo`, hope that doesn't mess anything up, should be minor. I think it needs python >= 3.11, not sure if that's defined in your documentation anywhere.